### PR TITLE
[APB-1896][AO] add agentCode mapping alongside sa or vat identifiers mapping

### DIFF
--- a/app/uk/gov/hmrc/agentmapping/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentmapping/audit/AuditService.scala
@@ -54,6 +54,8 @@ class AuditService @Inject() (val auditConnector: AuditConnector) {
         auditEvent(AgentMappingEvent.CreateMapping, "create-mapping", Seq("authProviderId" -> authProviderId, "saAgentRef" -> identifier.value, "agentReferenceNumber" -> arn.value, "duplicate" -> duplicate))
       case AgentRefNo =>
         auditEvent(AgentMappingEvent.CreateMapping, "create-mapping", Seq("authProviderId" -> authProviderId, "vatAgentRef" -> identifier.value, "agentReferenceNumber" -> arn.value, "duplicate" -> duplicate))
+      case AgentCode =>
+        auditEvent(AgentMappingEvent.CreateMapping, "create-mapping", Seq("authProviderId" -> authProviderId, "agentCode" -> identifier.value, "agentReferenceNumber" -> arn.value, "duplicate" -> duplicate))
     }
   }
 

--- a/app/uk/gov/hmrc/agentmapping/model/Mapping.scala
+++ b/app/uk/gov/hmrc/agentmapping/model/Mapping.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.agentmapping.model
 
 import play.api.libs.json.Format
 import play.api.libs.json.Json.format
-import uk.gov.hmrc.agentmapping.repository.{ SaAgentReferenceMapping, VatAgentReferenceMapping }
+import uk.gov.hmrc.agentmapping.repository.{ AgentCodeMapping, SaAgentReferenceMapping, VatAgentReferenceMapping }
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 case class Mapping(arn: String, identifiers: Seq[Identifier])
@@ -37,4 +37,10 @@ case class VatAgentReferenceMappings(mappings: List[VatAgentReferenceMapping])
 
 object VatAgentReferenceMappings extends ReactiveMongoFormats {
   implicit val formats: Format[VatAgentReferenceMappings] = format[VatAgentReferenceMappings]
+}
+
+case class AgentCodeMappings(mappings: List[AgentCodeMapping])
+
+object AgentCodeMappings extends ReactiveMongoFormats {
+  implicit val formats: Format[AgentCodeMappings] = format[AgentCodeMappings]
 }

--- a/app/uk/gov/hmrc/agentmapping/model/Names.scala
+++ b/app/uk/gov/hmrc/agentmapping/model/Names.scala
@@ -20,6 +20,7 @@ object Names {
 
   val IRAgentReference = "IRAgentReference"
   val AgentRefNo = "AgentRefNo"
+  val AgentCode = "AgentCode"
 
   val `IR-SA-AGENT` = "IR-SA-AGENT"
   val `HMCE-VAT-AGNT` = "HMCE-VAT-AGNT"

--- a/app/uk/gov/hmrc/agentmapping/repository/AgentCodeMappingRepository.scala
+++ b/app/uk/gov/hmrc/agentmapping/repository/AgentCodeMappingRepository.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentmapping.repository
+
+import javax.inject.{ Inject, Singleton }
+
+import play.api.libs.json.Format
+import play.api.libs.json.Json.{ format, toJsFieldJsValueWrapper }
+import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.commands.WriteResult
+import reactivemongo.api.indexes.Index
+import reactivemongo.api.indexes.IndexType.Ascending
+import reactivemongo.bson.BSONObjectID
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+import uk.gov.hmrc.mongo.ReactiveRepository
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+
+import scala.collection.Seq
+import scala.concurrent.{ ExecutionContext, Future }
+
+case class AgentCodeMapping(arn: String, agentCode: String)
+
+object AgentCodeMapping extends ReactiveMongoFormats {
+  implicit val formats: Format[AgentCodeMapping] = format[AgentCodeMapping]
+}
+
+@Singleton
+class AgentCodeMappingRepository @Inject() (mongoComponent: ReactiveMongoComponent) extends ReactiveRepository[AgentCodeMapping, BSONObjectID]("agent-mapping-agent-code", mongoComponent.mongoConnector.db, AgentCodeMapping.formats, ReactiveMongoFormats.objectIdFormats)
+  with MappingRepository with StrictlyEnsureIndexes[AgentCodeMapping, BSONObjectID] {
+
+  def findBy(arn: Arn)(implicit ec: ExecutionContext): Future[List[AgentCodeMapping]] = {
+    find(Seq("arn" -> Some(arn)).map(option => option._1 -> toJsFieldJsValueWrapper(option._2.get)): _*)
+  }
+
+  override def indexes = Seq(
+    Index(Seq("arn" -> Ascending, "agentCode" -> Ascending), Some("arnAndAgentCode"), unique = true),
+    Index(Seq("arn" -> Ascending), Some("AgentReferenceNumber")))
+
+  def createMapping(arn: Arn, identifierValue: String)(implicit ec: ExecutionContext): Future[Unit] = {
+    insert(AgentCodeMapping(arn.value, identifierValue)).map(_ => ())
+  }
+
+  def delete(arn: Arn)(implicit ec: ExecutionContext): Future[WriteResult] = {
+    remove("arn" -> arn.value)
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -22,16 +22,16 @@ lazy val compileDeps = Seq(
   "de.threedimensions" %% "metrics-play" % "2.5.13",
   "uk.gov.hmrc" %% "domain" % "5.1.0",
   "uk.gov.hmrc" %% "agent-kenshoo-monitoring" % "2.4.0",
-  "uk.gov.hmrc" %% "play-reactivemongo" % "6.1.0",
+  "uk.gov.hmrc" %% "play-reactivemongo" % "6.2.0",
   ws
 )
 
 def testDeps(scope: String) = Seq(
   "uk.gov.hmrc" %% "hmrctest" % "3.0.0" % scope,
   "org.scalatest" %% "scalatest" % "3.0.5" % scope,
-  "org.mockito" % "mockito-core" % "2.13.0" % scope,
+  "org.mockito" % "mockito-core" % "2.15.0" % scope,
   "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % scope,
-  "com.github.tomakehurst" % "wiremock" % "2.14.0" % scope,
+  "com.github.tomakehurst" % "wiremock" % "2.15.0" % scope,
   "org.pegdown" % "pegdown" % "1.6.0" % scope,
   "uk.gov.hmrc" %% "reactivemongo-test" % "2.0.0" % scope
 )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,3 +7,4 @@ GET  /mappings/:arn                        @uk.gov.hmrc.agentmapping.controller.
 
 GET  /mappings/sa/:arn                     @uk.gov.hmrc.agentmapping.controller.MappingController.findSaMappings(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
 GET  /mappings/vat/:arn                    @uk.gov.hmrc.agentmapping.controller.MappingController.findVatMappings(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
+GET  /mappings/agentcode/:arn              @uk.gov.hmrc.agentmapping.controller.MappingController.findAgentCodeMappings(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)

--- a/it/uk/gov/hmrc/agentmapping/repository/AgentCodeMappingRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentmapping/repository/AgentCodeMappingRepositoryISpec.scala
@@ -1,0 +1,106 @@
+package uk.gov.hmrc.agentmapping.repository
+
+import play.api.test.FakeApplication
+import reactivemongo.api.commands.WriteResult
+import reactivemongo.core.errors.DatabaseException
+import uk.gov.hmrc.agentmapping.support.MongoApp
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AgentCodeMappingRepositoryISpec extends UnitSpec with MongoApp {
+  override implicit lazy val app: FakeApplication = FakeApplication(
+    additionalConfiguration = mongoConfiguration)
+
+  val arn1 = Arn("ARN00001")
+  val arn2 = Arn("ARN00002")
+
+  val agentCode1 = "Ref0001"
+  val agentCode2 = "Ref0002"
+
+  def repo: AgentCodeMappingRepository = app.injector.instanceOf[AgentCodeMappingRepository]
+
+  override def beforeEach() {
+    super.beforeEach()
+    await(repo.ensureIndexes)
+  }
+
+  "createMapping" should {
+    "create a mapping" in {
+      await(repo.createMapping(arn1, agentCode1))
+
+      val result = await(repo.find())
+
+      result.size shouldBe 1
+      result.head.arn shouldBe arn1.value
+      result.head.agentCode shouldBe agentCode1
+
+    }
+
+    "not allow duplicate mappings to be created for the same ARN and SA Agent Reference" in {
+      await(repo.createMapping(arn1, agentCode1))
+
+      val e = intercept[DatabaseException] {
+        await(repo.createMapping(arn1, agentCode1))
+      }
+
+      e.getMessage() should include("E11000")
+    }
+
+    "allow more than one SA Agent Reference to be mapped to the same ARN" in {
+      await(repo.createMapping(arn1, agentCode1))
+      await(repo.createMapping(arn1, agentCode2))
+
+      val result = await(repo.find())
+
+      result.size shouldBe 2
+      result.head.arn shouldBe arn1.value
+      result.head.agentCode shouldBe agentCode1
+      result(1).arn shouldBe arn1.value
+      result(1).agentCode shouldBe agentCode2
+    }
+  }
+
+  "findBy arn" should {
+    "find all mpppings for an arn" in {
+      await(repo.createMapping(arn1, agentCode1))
+      await(repo.createMapping(arn1, agentCode2))
+      await(repo.createMapping(arn2, agentCode2))
+
+      val result: List[AgentCodeMapping] = await(repo.findBy(arn1))
+
+      result.size shouldBe 2
+    }
+
+    "return an empty list when no match is found" in {
+      await(repo.createMapping(arn1, agentCode1))
+      val result = await(repo.findBy(arn2))
+      result.size shouldBe 0
+    }
+  }
+
+  "delete by arn and SA Agent Reference" should {
+    "delete a matching record" in {
+      await(repo.createMapping(arn1, agentCode1))
+      await(repo.createMapping(arn2, agentCode2))
+
+      val mappings: List[AgentCodeMapping] = await(repo.findAll())
+      mappings.size shouldBe 2
+
+      val result: WriteResult = await(repo.delete(arn1))
+      result.code shouldBe None
+
+      val mappingsAfterDelete: List[AgentCodeMapping] = await(repo.findAll())
+      mappingsAfterDelete.size shouldBe 1
+    }
+
+    "tolerate no matching record" in {
+      val mappings: List[AgentCodeMapping] = await(repo.findAll())
+      mappings.size shouldBe 0
+
+      val result: WriteResult = await(repo.delete(arn1))
+      result.code shouldBe None
+    }
+  }
+}

--- a/it/uk/gov/hmrc/agentmapping/stubs/AuthStubs.scala
+++ b/it/uk/gov/hmrc/agentmapping/stubs/AuthStubs.scala
@@ -12,7 +12,7 @@ trait AuthStubs {
         .withHeader("WWW-Authenticate", s"""MDTP detail="${mdtpDetail}"""")))
   }
 
-  def givenUserAuthorisedFor(enrolment: String, identifierName: String, identifierValue: String, ggCredId: String, affinityGroup: AffinityGroup = AffinityGroup.Agent): Unit = {
+  def givenUserAuthorisedFor(enrolment: String, identifierName: String, identifierValue: String, ggCredId: String, affinityGroup: AffinityGroup = AffinityGroup.Agent, agentCodeOpt: Option[String]): Unit = {
     stubFor(post(urlEqualTo("/auth/authorise")).atPriority(1)
       .withRequestBody(
         equalToJson(
@@ -27,12 +27,12 @@ trait AuthStubs {
              |    "enrolment":"$enrolment"
              |  }
              |],
-             |"retrieve":["authProviderId"]
+             |"retrieve":["credentials","agentCode"]
           }""".stripMargin, true, false))
       .willReturn(aResponse()
         .withStatus(200)
         .withHeader("Content-Type", "application/json")
-        .withBody(s"""{"authProviderId":{"ggCredId":"$ggCredId"}}""")))
+        .withBody(s"""{ "credentials": {"providerId": "$ggCredId", "providerType": "GovernmmentGateway"} ${agentCodeOpt.map(ac => s""", "agentCode": "$ac" """).getOrElse("")} }""")))
 
     stubFor(post(urlEqualTo("/auth/authorise")).atPriority(2)
       .willReturn(aResponse()
@@ -40,7 +40,7 @@ trait AuthStubs {
         .withHeader("WWW-Authenticate", "MDTP detail=\"InsufficientEnrolments\"")))
   }
 
-  def givenUserAuthorisedForMultiple(enrolments: Set[Enrolment], ggCredId: String, affinityGroup: AffinityGroup = AffinityGroup.Agent): Unit = {
+  def givenUserAuthorisedForMultiple(enrolments: Set[Enrolment], ggCredId: String, affinityGroup: AffinityGroup = AffinityGroup.Agent, agentCodeOpt: Option[String]): Unit = {
     stubFor(post(urlEqualTo("/auth/authorise")).atPriority(1)
       .withRequestBody(
         equalToJson(
@@ -56,13 +56,13 @@ trait AuthStubs {
               |      }""".stripMargin).mkString(",")
           }
               |   ],
-              |  "retrieve":["authProviderId"]
+              |  "retrieve":["credentials","agentCode"]
               |}
            """.stripMargin, true, false))
       .willReturn(aResponse()
         .withStatus(200)
         .withHeader("Content-Type", "application/json")
-        .withBody(s"""{"authProviderId":{"ggCredId":"$ggCredId"}}""")))
+        .withBody(s"""{ "credentials": {"providerId": "$ggCredId", "providerType": "GovernmmentGateway"} ${agentCodeOpt.map(ac => s""", "agentCode": "$ac" """).getOrElse("")} }""")))
 
     stubFor(post(urlEqualTo("/auth/authorise")).atPriority(2)
       .willReturn(aResponse()


### PR DESCRIPTION
This PR addresses issue with checking the existence of old relationship for VAT where we need to compare a list of old agentCodes returned from GG with an `old` agentCode for the given ARN. This old `agentCode` will be obtained by querying new `agent-mapping` endpoint `/mappings/agentcode/:arn`.